### PR TITLE
Filenames below asses thumbnail in bucket

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -77,7 +77,7 @@ class Admin::AssetsController < Admin::ResourceController
       render :nothing => true and return
     end
     asset_type = @asset.image? ? 'image' : 'link'
-    session[:bucket][@asset.asset.url] = { :thumbnail => @asset.thumbnail(:thumbnail), :id => @asset.id, :title => @asset.title, :type => asset_type }
+    session[:bucket][@asset.asset.url] = { :thumbnail => @asset.thumbnail(:thumbnail), :id => @asset.id, :title => @asset.title, :type => asset_type, :filename => @asset.asset_file_name }
 
     render :update do |page|
       page[:bucket_list].replace_html "#{render :partial => 'bucket'}"

--- a/app/views/admin/assets/_bucket.html.haml
+++ b/app/views/admin/assets/_bucket.html.haml
@@ -1,7 +1,7 @@
 %ul#bucket_list
   - if session[:bucket]
     - session[:bucket].each do |url, info| 
-      = render :partial => 'admin/assets/bucket_asset', :locals => { :asset_url => url, :asset_id => info[:id], :asset_type => info[:type], :asset_title => info[:title], :asset_thumbnail =>info[:thumbnail], :page => @page }
+      = render :partial => 'admin/assets/bucket_asset', :locals => { :asset_url => url, :asset_id => info[:id], :asset_type => info[:type], :asset_title => info[:title], :asset_thumbnail =>info[:thumbnail], :asset_filename => info[:filename], :page => @page }
   - else
     %li
       %p.note

--- a/app/views/admin/assets/_bucket_asset.html.haml
+++ b/app/views/admin/assets/_bucket_asset.html.haml
@@ -7,3 +7,6 @@
     = link_to image_tag('/images/assets/edit.png'), edit_admin_asset_url(asset_id), :class => "edit_asset", :title => t("paperclipped.edit_asset", :asset => asset_title)
     - if page && !page.new_record?
       = link_to image_tag('/images/assets/add.png'), attach_page_asset_url(:asset => asset_id, :page => page.id), :class => "add_asset", :title => t("paperclipped.attach_to_page")
+      
+  .filename
+    = asset_filename

--- a/public/stylesheets/admin/assets.css
+++ b/public/stylesheets/admin/assets.css
@@ -65,6 +65,13 @@ table td.add-to-bucket a { background: url("../../images/admin/plus.png") no-rep
   -box-shadow: rgba(0, 0, 0, 0.148438) 2px 2px 3px;
 }
 
+#asset-bucket div.filename{
+  color: #333;
+  font-size: 60%;
+  width: 110px;
+  overflow: hidden;
+}
+
 #assets .pane,
 #content .form-area .asset {
   background: #F5F1E2 url(/images/admin/vertical_tan_gradient.png) repeat-x 0% 0%;
@@ -105,7 +112,7 @@ table td.add-to-bucket a { background: url("../../images/admin/plus.png") no-rep
 
 #bucket ul, #page-attachments ul, #search-results ul { list-style: none; margin: 0; padding: 0 10px 0 0;}
 
-#assets li { position: relative; float:left; margin: 8px 8px 0 8px; height: 106px; padding-right: 24px;}
+#assets li { position: relative; float:left; margin: 8px 8px 0 8px; height: 126px; padding-right: 24px;}
 #assets .asset  { position: relative; }
 #assets .asset img { padding: 3px; background-color:#eaeaea; border: 1px solid #ccc; }
   


### PR DESCRIPTION
Here's a very simple implementation of a feature that bugs my clients.  When we upload PDFs and such the thumbnail is basically useless, so you have to mouseover each thumb to get the filename.

This is a simple implementation of showing the filename below the thumbnail.
