### PR TITLE
Allow configured "Additional thumbnails" setting to work for thumbail and icon styles

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -127,8 +127,8 @@ class Asset < ActiveRecord::Base
       else
         thumbnails = {}
       end
-      thumbnails[:icon] = ['42x42#', :png]
-      thumbnails[:thumbnail] = ['100x100>', :png]
+      thumbnails[:icon] ||= ['42x42#', :png]
+      thumbnails[:thumbnail] ||= ['100x100>', :png]
       thumbnails
     end
  


### PR DESCRIPTION
This simple fix would save great frustration for noobies like me. The current version hardcodes the :thumbnail and :icon style, overwriting any configuration entered on the server. I simply changed "=" to "||=" for both these hard-coded settings, to allow my configs to work according to the documentation.
