### PR TITLE
Serve assets through a CDN (master)

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -174,6 +174,7 @@ class Asset < ActiveRecord::Base
                       :access_key_id => Radiant::Config["assets.s3.key"],
                       :secret_access_key => Radiant::Config["assets.s3.secret"]
                     },
+                    :s3_host_alias => Radiant::Config["assets.s3.host_alias"],
                     :bucket => Radiant::Config["assets.s3.bucket"],
                     :url => Radiant::Config["assets.url"] ? Radiant::Config["assets.url"] : "/:class/:id/:basename:no_original_style.:extension", 
                     :path => Radiant::Config["assets.path"] ? Radiant::Config["assets.path"] : ":rails_root/public/:class/:id/:basename:no_original_style.:extension"


### PR DESCRIPTION
I need to serve assets through a CDN and stock paperclip supports that by specifying:

```
:s3_host_alias => "www.cdn.com",
:url => ":s3_alias_url"
```

Currently, paperclipped doesn't have a setting for `:s3_host_alias`, so this pull request attempts to remedy that.
